### PR TITLE
Simul access fix

### DIFF
--- a/SwiftCBOR/CBORDecoder.swift
+++ b/SwiftCBOR/CBORDecoder.swift
@@ -93,8 +93,8 @@ public class CBORDecoder {
 
 		case let b where 0x60 <= b && b <= 0x77: return CBOR.utf8String(try Util.decodeUtf8(try istream.popBytes(Int(b - 0x60))))
 		case 0x78: 
-            let numBytes: Int =  Int(try istream.popByte())
-            return CBOR.utf8String(try Util.decodeUtf8(try istream.popBytes(numBytes)))
+            		let numBytes: Int =  Int(try istream.popByte())
+            		return CBOR.utf8String(try Util.decodeUtf8(try istream.popBytes(numBytes)))
 		case 0x79: return CBOR.utf8String(try Util.decodeUtf8(try istream.popBytes(Int(try readUInt(2) as UInt16))))
 		case 0x7a: return CBOR.utf8String(try Util.decodeUtf8(try istream.popBytes(Int(try readUInt(4) as UInt32))))
 		case 0x7b: return CBOR.utf8String(try Util.decodeUtf8(try istream.popBytes(Int(try readUInt(8) as UInt64))))

--- a/SwiftCBOR/CBORDecoder.swift
+++ b/SwiftCBOR/CBORDecoder.swift
@@ -92,7 +92,9 @@ public class CBORDecoder {
 		case 0x5f: return CBOR.byteString(try readUntilBreak().flatMap { x -> [UInt8] in guard case .byteString(let r) = x else { throw CBORError.wrongTypeInsideSequence }; return r })
 
 		case let b where 0x60 <= b && b <= 0x77: return CBOR.utf8String(try Util.decodeUtf8(try istream.popBytes(Int(b - 0x60))))
-		case 0x78: return CBOR.utf8String(try Util.decodeUtf8(try istream.popBytes(Int(try istream.popByte()))))
+		case 0x78: 
+            let numBytes: Int =  Int(try istream.popByte())
+            return CBOR.utf8String(try Util.decodeUtf8(try istream.popBytes(numBytes)))
 		case 0x79: return CBOR.utf8String(try Util.decodeUtf8(try istream.popBytes(Int(try readUInt(2) as UInt16))))
 		case 0x7a: return CBOR.utf8String(try Util.decodeUtf8(try istream.popBytes(Int(try readUInt(4) as UInt32))))
 		case 0x7b: return CBOR.utf8String(try Util.decodeUtf8(try istream.popBytes(Int(try readUInt(8) as UInt64))))


### PR DESCRIPTION
When trying to decode a UUID string (format "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX") I encountered a crash.

Code:
```swift
        // 78 24 61 66 31 63 35 36 37 38 2D 31 33 38 38 2D 34 61 66 61 2D 34 61 64 34 2D 30 35 32 34 39 65 36 65 32 39 37 30
        let data: [UInt8] = [0x78, 0x24, 0x61, 0x66, 0x31, 0x63, 0x35, 0x36, 0x37, 0x38, 0x2D, 0x31, 0x33, 0x38, 0x38, 0x2D, 0x34, 0x61, 0x66, 0x61, 0x2D, 0x34, 0x61, 0x64, 0x34, 0x2D, 0x30, 0x35, 0x32, 0x34, 0x39, 0x65, 0x36, 0x65, 0x32, 0x39, 0x37, 0x30]
        do {
            let cbor = try CBOR.decode(data)
        } catch {
        }
```
Crash:
```
Simultaneous accesses to 0x174078890, but modification requires exclusive access.
Previous access (a modification) started at sc-test`CBORDecoder.decodeItem() + 10808 (0x1000a5958).
Current access (a modification) started at:
0    libswiftCore.dylib                 0x0000000100601304 swift_beginAccess + 468
1    sc-test                            0x00000001000a2f20 CBORDecoder.decodeItem() + 10904
2    sc-test                            0x00000001000a0e70 static CBOR.decode(_:) + 116
3    sc-test                            0x00000001000b17d4 ViewController.viewDidLoad() + 1108
4    sc-test                            0x00000001000b21f4 @objc ViewController.viewDidLoad() + 40
5    UIKit                              0x0000000189b23504 <redacted> + 1056
6    UIKit                              0x0000000189b234d0 <redacted> + 28
7    UIKit                              0x0000000189b29c4c <redacted> + 76
8    UIKit                              0x0000000189b27028 <redacted> + 272
9    UIKit                              0x0000000189b9965c <redacted> + 48
10   UIKit                              0x0000000189da4cd4 <redacted> + 4068
11   UIKit                              0x0000000189dab190 <redacted> + 1656
12   UIKit                              0x0000000189dc00d4 <redacted> + 48
13   UIKit                              0x0000000189da8744 <redacted> + 168
14   FrontBoardServices                 0x000000018584b908 <redacted> + 36
15   FrontBoardServices                 0x000000018584b6e8 <redacted> + 176
16   FrontBoardServices                 0x000000018584bb08 <redacted> + 56
17   CoreFoundation                     0x0000000183c22b44 <redacted> + 24
18   CoreFoundation                     0x0000000183c22298 <redacted> + 524
19   CoreFoundation                     0x0000000183c1fd80 <redacted> + 804
20   CoreFoundation                     0x0000000183b4e0fc CFRunLoopRunSpecific + 444
21   UIKit                              0x0000000189b8e550 <redacted> + 608
22   UIKit                              0x0000000189b89464 UIApplicationMain + 208
23   sc-test                            0x000000010011b708 main + 76
24   libdyld.dylib                      0x0000000182b315b4 <redacted> + 4
```

It seems that the crash occurs because we are doing `istream.popByte()` and `istream.popBytes(...)` in the same line. Separating the calls fixed the issue for me.