### PR TITLE
Add value field to CBOR to get underlying value

### DIFF
--- a/SwiftCBOR/CBOR.swift
+++ b/SwiftCBOR/CBOR.swift
@@ -19,6 +19,26 @@ public indirect enum CBOR : Equatable, Hashable,
 	case float(Float32)
 	case double(Float64)
 	case `break`
+		
+	public var value : Any? {
+		switch self {
+		case let .unsignedInt(l): return l
+		case let .negativeInt(l): return l
+		case let .byteString(l):  return l
+		case let .utf8String(l):  return l
+		case let .array(l):       return l
+		case let .map(l):         return l
+		case let .tagged(t, l):   return (t, l)
+		case let .simple(l):      return l
+		case let .boolean(l):     return l
+		case .null:               return nil
+		case .undefined:          return nil
+		case let .half(l):        return l
+		case let .float(l):       return l
+		case let .double(l):      return l
+		case .break:              return nil
+		}
+	}
 
 	public var hashValue : Int {
 		switch self {


### PR DESCRIPTION
Not sure if there was already a way to do this (if there is please let me know), but after I decoded a CBOR payload, I was unable to get the underlying value. 

The new value field will return the underlying value as a `Any?` type which gives the developer the ability to cast the value to the type (assuming s/he knows the type).

```swift
if let myString = cbor["myString"]?.value as? String {
    print("My String: \(myString)")
}
```

Let me know what you think.