### PR TITLE
Fix protection level

### DIFF
--- a/SwiftCBOR/CBORDecoder.swift
+++ b/SwiftCBOR/CBORDecoder.swift
@@ -5,7 +5,7 @@ public enum CBORError : Error {
 }
 
 extension CBOR {
-    static func decode(_ input: [UInt8]) throws -> CBOR? {
+    static public func decode(_ input: [UInt8]) throws -> CBOR? {
         return try CBORDecoder(input: input).decodeItem()
     }
 }


### PR DESCRIPTION
Swift 4 raises the error: "'decode' is inaccessible due to 'internal' protection level"
when trying to build the example:

    let decoded = try! CBOR.decode([0x9f, ...])
    print(decoded)