### PR TITLE
Prevent use after free in `rawBytes`

### DIFF
--- a/SwiftCBOR/CBOREncoder.swift
+++ b/SwiftCBOR/CBOREncoder.swift
@@ -8,11 +8,9 @@ let isBigEndian = Int(bigEndian: 42) == 42
  T must be a simple type. It cannot be a collection type.
  */
 func rawBytes<T>(of x: T) -> [UInt8] {
-    let size = MemoryLayout<T>.size
-    let bigendian_res = UnsafePointer<T>([x]).withMemoryRebound(to: UInt8.self, capacity: size, { ptr in
-        return (0..<size).map { (ptr + $0).pointee }
-    })
-    return isBigEndian ? bigendian_res : bigendian_res.reversed()
+    var x = x
+    let bigEndianResult = withUnsafeBytes(of: &x) { Array($0) }
+    return isBigEndian ? bigEndianResult : bigEndianResult.reversed()
 }
 
 /// Defines basic CBOR.encode API.

--- a/SwiftCBOR/CBOREncoder.swift
+++ b/SwiftCBOR/CBOREncoder.swift
@@ -8,7 +8,7 @@ let isBigEndian = Int(bigEndian: 42) == 42
  T must be a simple type. It cannot be a collection type.
  */
 func rawBytes<T>(of x: T) -> [UInt8] {
-    var x = x
+    var x = x // create mutable copy for `withUnsafeBytes`
     let bigEndianResult = withUnsafeBytes(of: &x) { Array($0) }
     return isBigEndian ? bigEndianResult : bigEndianResult.reversed()
 }

--- a/SwiftCBOR/CBOREncoder.swift
+++ b/SwiftCBOR/CBOREncoder.swift
@@ -8,8 +8,8 @@ let isBigEndian = Int(bigEndian: 42) == 42
  T must be a simple type. It cannot be a collection type.
  */
 func rawBytes<T>(of x: T) -> [UInt8] {
-    var x = x // create mutable copy for `withUnsafeBytes`
-    let bigEndianResult = withUnsafeBytes(of: &x) { Array($0) }
+    var mutable = x // create mutable copy for `withUnsafeBytes`
+    let bigEndianResult = withUnsafeBytes(of: &mutable) { Array($0) }
     return isBigEndian ? bigEndianResult : bigEndianResult.reversed()
 }
 


### PR DESCRIPTION
The memory of `[x]` seems to be released before the closure is invoked.

The easiest mitigation is to assign the array to a local variable first `let array = [x]` and then use it - in that case it seems to survive until it goes out of scope at the end of the function.

I took the liberty to simplify the code a bit.