### PR TITLE
Default to UInt64 in more places

### DIFF
--- a/SwiftCBOR/CBOR.swift
+++ b/SwiftCBOR/CBOR.swift
@@ -1,16 +1,14 @@
-
-
 public indirect enum CBOR : Equatable, Hashable,
 	ExpressibleByNilLiteral, ExpressibleByIntegerLiteral, ExpressibleByStringLiteral,
 	ExpressibleByArrayLiteral, ExpressibleByDictionaryLiteral, ExpressibleByBooleanLiteral,
 	ExpressibleByFloatLiteral {
-	case unsignedInt(UInt)
-	case negativeInt(UInt)
+	case unsignedInt(UInt64)
+	case negativeInt(UInt64)
 	case byteString([UInt8])
 	case utf8String(String)
 	case array([CBOR])
 	case map([CBOR : CBOR])
-	case tagged(UInt8, CBOR)
+	case tagged(Tag, CBOR)
 	case simple(UInt8)
 	case boolean(Bool)
 	case null
@@ -26,17 +24,17 @@ public indirect enum CBOR : Equatable, Hashable,
 		case let .negativeInt(l): return l.hashValue
 		case let .byteString(l):  return Util.djb2Hash(l.map { Int($0) })
 		case let .utf8String(l):  return l.hashValue
-		case let .array(l):	      return Util.djb2Hash(l.map { $0.hashValue })
+		case let .array(l):       return Util.djb2Hash(l.map { $0.hashValue })
 		case let .map(l):         return Util.djb2Hash(l.map { $0.hashValue &+ $1.hashValue })
 		case let .tagged(t, l):   return t.hashValue &+ l.hashValue
 		case let .simple(l):      return l.hashValue
 		case let .boolean(l):     return l.hashValue
-		case .null:                return -1
-		case .undefined:           return -2
+		case .null:               return -1
+		case .undefined:          return -2
 		case let .half(l):        return l.hashValue
 		case let .float(l):       return l.hashValue
 		case let .double(l):      return l.hashValue
-		case .break:               return Int.min
+		case .break:              return Int.min
 		}
 	}
 	
@@ -59,7 +57,11 @@ public indirect enum CBOR : Equatable, Hashable,
 
 	public init(nilLiteral: ()) { self = .null }
 	public init(integerLiteral value: Int) {
-		if value < 0 { self = .negativeInt(UInt(-value) - 1) } else { self = .unsignedInt(UInt(value)) }
+		if value < 0 {
+			self = .negativeInt(~UInt64(bitPattern: Int64(value)))
+		} else {
+			self = .unsignedInt(UInt64(value))
+		}
 	}
 	public init(extendedGraphemeClusterLiteral value: String) { self = .utf8String(value) }
 	public init(unicodeScalarLiteral value: String) { self = .utf8String(value) }
@@ -74,25 +76,75 @@ public indirect enum CBOR : Equatable, Hashable,
 	}
 	public init(booleanLiteral value: Bool) { self = .boolean(value) }
 	public init(floatLiteral value: Float32) { self = .float(value) }
+
+	public static func ==(lhs: CBOR, rhs: CBOR) -> Bool {
+		switch (lhs, rhs) {
+		case (let .unsignedInt(l), let .unsignedInt(r)): return l == r
+		case (let .negativeInt(l), let .negativeInt(r)): return l == r
+		case (let .byteString(l),  let .byteString(r)):  return l == r
+		case (let .utf8String(l),  let .utf8String(r)):  return l == r
+		case (let .array(l),       let .array(r)):       return l == r
+		case (let .map(l),         let .map(r)):         return l == r
+		case (let .tagged(tl, l),  let .tagged(tr, r)):  return tl == tr && l == r
+		case (let .simple(l),      let .simple(r)):      return l == r
+		case (let .boolean(l),     let .boolean(r)):     return l == r
+		case (.null,               .null):               return true
+		case (.undefined,          .undefined):          return true
+		case (let .half(l),        let .half(r)):        return l == r
+		case (let .float(l),       let .float(r)):       return l == r
+		case (let .double(l),      let .double(r)):      return l == r
+		case (.break,              .break):              return true
+		case (.unsignedInt, _): return false
+		case (.negativeInt, _): return false
+		case (.byteString,  _): return false
+		case (.utf8String,  _): return false
+		case (.array,       _): return false
+		case (.map,         _): return false
+		case (.tagged,      _): return false
+		case (.simple,      _): return false
+		case (.boolean,     _): return false
+		case (.null,        _): return false
+		case (.undefined,   _): return false
+		case (.half,        _): return false
+		case (.float,       _): return false
+		case (.double,      _): return false
+		case (.break,       _): return false
+		}
+	}
+
+	public struct Tag: RawRepresentable, Equatable, Hashable {
+		public let rawValue: UInt64
+
+		public init(rawValue: UInt64) {
+			self.rawValue = rawValue
+		}
+	}
 }
 
-public func ==(lhs: CBOR, rhs: CBOR) -> Bool {
-	switch (lhs, rhs) {
-	case (let .unsignedInt(l), let .unsignedInt(r)): return l == r
-	case (let .negativeInt(l), let .negativeInt(r)): return l == r
-	case (let .byteString(l),  let .byteString(r)):  return l == r
-	case (let .utf8String(l),  let .utf8String(r)):  return l == r
-	case (let .array(l),       let .array(r)):       return l == r
-	case (let .map(l),         let .map(r)):         return l == r
-	case (let .tagged(tl, l),  let .tagged(tr, r)):  return tl == tr && l == r
-	case (let .simple(l),      let .simple(r)):      return l == r
-	case (let .boolean(l),     let .boolean(r)):     return l == r
-	case (.null,               .null):               return true
-	case (.undefined,          .undefined):          return true
-	case (let .half(l),        let .half(r)):        return l == r
-	case (let .float(l),       let .float(r)):       return l == r
-	case (let .double(l),      let .double(r)):      return l == r
-	case (.break,              .break):              return true
-	default:                                         return false
-	}
+extension CBOR.Tag {
+	static let standardDateTimeString = CBOR.Tag(rawValue: 0)
+	static let epochBasedDateTime = CBOR.Tag(rawValue: 1)
+	static let positiveBignum = CBOR.Tag(rawValue: 2)
+	static let negativeBignum = CBOR.Tag(rawValue: 3)
+	static let decimalFraction = CBOR.Tag(rawValue: 4)
+	static let bigfloat = CBOR.Tag(rawValue: 5)
+
+	// 6...20 unassigned
+
+	static let expectedConversionToBase64URLEncoding = CBOR.Tag(rawValue: 21)
+	static let expectedConversionToBase64Encoding = CBOR.Tag(rawValue: 22)
+	static let expectedConversionToBase16Encoding = CBOR.Tag(rawValue: 23)
+	static let encodedCBORDataItem = CBOR.Tag(rawValue: 24)
+
+	// 25...31 unassigned
+
+	static let uri = CBOR.Tag(rawValue: 32)
+	static let base64Url = CBOR.Tag(rawValue: 33)
+	static let base64 = CBOR.Tag(rawValue: 34)
+	static let regularExpression = CBOR.Tag(rawValue: 35)
+	static let mimeMessage = CBOR.Tag(rawValue: 36)
+
+	// 37...55798 unassigned
+
+	static let selfDescribeCBOR = CBOR.Tag(rawValue: 55799)
 }

--- a/SwiftCBOR/CBORDecoder.swift
+++ b/SwiftCBOR/CBORDecoder.swift
@@ -1,13 +1,14 @@
 public enum CBORError : Error {
 	case unfinishedSequence
 	case wrongTypeInsideSequence
+	case tooLongSequence
 	case incorrectUTF8String
 }
 
 extension CBOR {
-    static public func decode(_ input: [UInt8]) throws -> CBOR? {
-        return try CBORDecoder(input: input).decodeItem()
-    }
+	static public func decode(_ input: [UInt8]) throws -> CBOR? {
+		return try CBORDecoder(input: input).decodeItem()
+	}
 }
 
 public class CBORDecoder {
@@ -26,18 +27,42 @@ public class CBORDecoder {
 		istream = ArrayUInt8(array: input)
 	}
 
-	private func readUInt<T: UnsignedInteger>(_ n: Int) throws -> T {
-        return UnsafeRawPointer(Array(try istream.popBytes(n).reversed())).load(as: T.self)
+	private func readBinaryNumber<T>(_ type: T.Type) throws -> T {
+		return UnsafeRawPointer(Array(try istream.popBytes(MemoryLayout<T>.size).reversed())).load(as: T.self)
+	}
+
+	private func readVarUInt(_ v: UInt8, base: UInt8) throws -> UInt64 {
+		guard v > base + 0x17 else { return UInt64(v - base) }
+
+		switch VarUIntSize(rawValue: v) {
+		case .uint8: return UInt64(try readBinaryNumber(UInt8.self))
+		case .uint16: return UInt64(try readBinaryNumber(UInt16.self))
+		case .uint32: return UInt64(try readBinaryNumber(UInt32.self))
+		case .uint64: return UInt64(try readBinaryNumber(UInt64.self))
+		}
+	}
+
+	private func readLength(_ v: UInt8, base: UInt8) throws -> Int {
+		let n = try readVarUInt(v, base: base)
+
+		guard n <= Int.max else {
+			throw CBORError.tooLongSequence
+		}
+
+		return Int(n)
 	}
 
 	private func readN(_ n: Int) throws -> [CBOR] {
-		return try (0..<n).map { _ in guard let r = try decodeItem() else { throw CBORError.unfinishedSequence }; return r }
+		return try (0..<n).map { _ in
+			guard let r = try decodeItem() else { throw CBORError.unfinishedSequence }
+			return r
+		}
 	}
 
 	private func readUntilBreak() throws -> [CBOR] {
-		var result : [CBOR] = []
+		var result: [CBOR] = []
 		var cur = try decodeItem()
-		while (cur != CBOR.break) {
+		while cur != CBOR.break {
 			guard let curr = cur else { throw CBORError.unfinishedSequence }
 			result.append(curr)
 			cur = try decodeItem()
@@ -46,7 +71,7 @@ public class CBORDecoder {
 	}
 
 	private func readNPairs(_ n: Int) throws -> [CBOR : CBOR] {
-		var result : [CBOR : CBOR] = [:]
+		var result: [CBOR: CBOR] = [:]
 		for _ in (0..<n) {
 			guard let key  = try decodeItem() else { throw CBORError.unfinishedSequence }
 			guard let val  = try decodeItem() else { throw CBORError.unfinishedSequence }
@@ -56,10 +81,10 @@ public class CBORDecoder {
 	}
 
 	private func readPairsUntilBreak() throws -> [CBOR : CBOR] {
-		var result : [CBOR : CBOR] = [:]
+		var result: [CBOR: CBOR] = [:]
 		var key = try decodeItem()
 		var val = try decodeItem()
-		while (key != CBOR.break) {
+		while key != CBOR.break {
 			guard let okey = key else { throw CBORError.unfinishedSequence }
 			guard let oval = val else { throw CBORError.unfinishedSequence }
 			result[okey] = oval
@@ -71,98 +96,58 @@ public class CBORDecoder {
 	}
 
 	public func decodeItem() throws -> CBOR? {
-		switch try istream.popByte() {
-		case let b where b <= 0x17: return CBOR.unsignedInt(UInt(b))
-		case 0x18: return CBOR.unsignedInt(UInt(try istream.popByte()))
-		case 0x19: return CBOR.unsignedInt(UInt(try readUInt(2) as UInt16))
-		case 0x1a: return CBOR.unsignedInt(UInt(try readUInt(4) as UInt32))
-		case 0x1b: return CBOR.unsignedInt(UInt(try readUInt(8) as UInt64))
+		let b = try istream.popByte()
 
-		case let b where 0x20 <= b && b <= 0x37: return CBOR.negativeInt(UInt(b - 0x20))
-		case 0x38: return CBOR.negativeInt(UInt(try istream.popByte()))
-		case 0x39: return CBOR.negativeInt(UInt(try readUInt(2) as UInt16))
-		case 0x3a: return CBOR.negativeInt(UInt(try readUInt(4) as UInt32))
-		case 0x3b: return CBOR.negativeInt(UInt(try readUInt(8) as UInt64))
+		switch b {
+		// positive integers
+		case 0x00...0x1b:
+			return CBOR.unsignedInt(try readVarUInt(b, base: 0x00))
 
-		case let b where 0x40 <= b && b <= 0x57: return CBOR.byteString(Array(try istream.popBytes(Int(b - 0x40))))
-		case 0x58:
-			let numBytes: Int = Int(try istream.popByte())
-			return CBOR.byteString(Array(try istream.popBytes(numBytes)))
-		case 0x59:
-			let numBytes: Int = Int(try readUInt(2) as UInt16)
-			return CBOR.byteString(Array(try istream.popBytes(numBytes)))
-		case 0x5a:
-			let numBytes: Int = Int(try readUInt(4) as UInt32)
-			return CBOR.byteString(Array(try istream.popBytes(numBytes)))
-		case 0x5b:
-			let numBytes: Int = Int(try readUInt(8) as UInt64)
-			return CBOR.byteString(Array(try istream.popBytes(numBytes)))
-		case 0x5f: return CBOR.byteString(try readUntilBreak().flatMap { x -> [UInt8] in guard case .byteString(let r) = x else { throw CBORError.wrongTypeInsideSequence }; return r })
+		// negative integers
+		case 0x20...0x3b:
+			return CBOR.negativeInt(try readVarUInt(b, base: 0x20))
 
-		case let b where 0x60 <= b && b <= 0x77: return CBOR.utf8String(try Util.decodeUtf8(try istream.popBytes(Int(b - 0x60))))
-		case 0x78:
-			let numBytes: Int = Int(try istream.popByte())
-			return CBOR.utf8String(try Util.decodeUtf8(try istream.popBytes(numBytes)))
-		case 0x79:
-			let numBytes: Int = Int(try readUInt(2) as UInt16)
-			return CBOR.utf8String(try Util.decodeUtf8(try istream.popBytes(numBytes)))
-		case 0x7a:
-			let numBytes: Int = Int(try readUInt(4) as UInt32)
-			return CBOR.utf8String(try Util.decodeUtf8(try istream.popBytes(numBytes)))
-		case 0x7b:
-			let numBytes: Int = Int(try readUInt(8) as UInt64)
-			return CBOR.utf8String(try Util.decodeUtf8(try istream.popBytes(numBytes)))
-		case 0x7f: return CBOR.utf8String(try readUntilBreak().map { x -> String in guard case .utf8String(let r) = x else { throw CBORError.wrongTypeInsideSequence }; return r }.joined(separator: ""))
+		// byte strings
+		case 0x40...0x5b:
+			let numBytes = try readLength(b, base: 0x40)
+			return CBOR.byteString(Array(try istream.popBytes(numBytes)))
+		case 0x5f:
+			return CBOR.byteString(try readUntilBreak().flatMap { x -> [UInt8] in
+				guard case .byteString(let r) = x else { throw CBORError.wrongTypeInsideSequence }
+				return r
+			})
 
-		case let b where 0x80 <= b && b <= 0x97: return CBOR.array(try readN(Int(b - 0x80)))
-		case 0x98: return CBOR.array(try readN(Int(try istream.popByte())))
-		case 0x99:
-			let numBytes: Int = Int(try readUInt(2) as UInt16)
+		// utf-8 strings
+		case 0x60...0x7b:
+			let numBytes = try readLength(b, base: 0x60)
+			return CBOR.utf8String(try Util.decodeUtf8(try istream.popBytes(numBytes)))
+		case 0x7f:
+			return CBOR.utf8String(try readUntilBreak().map { x -> String in
+				guard case .utf8String(let r) = x else { throw CBORError.wrongTypeInsideSequence }
+				return r
+			}.joined(separator: ""))
+
+		// arrays
+		case 0x80...0x9b:
+			let numBytes = try readLength(b, base: 0x80)
 			return CBOR.array(try readN(numBytes))
-		case 0x9a:
-			let numBytes: Int = Int(try readUInt(4) as UInt32)
-			return CBOR.array(try readN(numBytes))
-		case 0x9b:
-			let numBytes: Int = Int(try readUInt(8) as UInt64)
-			return CBOR.array(try readN(numBytes))
-		case 0x9f: return CBOR.array(try readUntilBreak())
+		case 0x9f:
+			return CBOR.array(try readUntilBreak())
 
-		case let b where 0xa0 <= b && b <= 0xb7: return CBOR.map(try readNPairs(Int(b - 0xa0)))
-		case 0xb8:
-			let numBytes: Int = Int(try istream.popByte())
+		// pairs
+		case 0xa0...0xbb:
+			let numBytes = try readLength(b, base: 0xa0)
 			return CBOR.map(try readNPairs(numBytes))
-		case 0xb9:
-			let numBytes: Int = Int(try readUInt(2) as UInt16)
-			return CBOR.map(try readNPairs(numBytes))
-		case 0xba:
-			let numBytes: Int = Int(try readUInt(4) as UInt32)
-			return CBOR.map(try readNPairs(numBytes))
-		case 0xbb:
-			let numBytes: Int = Int(try readUInt(8) as UInt64)
-			return CBOR.map(try readNPairs(numBytes))
-		case 0xbf: return CBOR.map(try readPairsUntilBreak())
+		case 0xbf:
+			return CBOR.map(try readPairsUntilBreak())
 
-		case let b where 0xc0 <= b && b <= 0xd7:
+		// tagged values
+		case 0xc0...0xdb:
+			let tag = try readVarUInt(b, base: 0xc0)
 			guard let item = try decodeItem() else { throw CBORError.unfinishedSequence }
-			return CBOR.tagged(UInt8(b - 0xc0), item)
-		case 0xd8:
-			let tag = UInt8(try istream.popByte())
-			guard let item = try decodeItem() else { throw CBORError.unfinishedSequence }
-			return CBOR.tagged(tag, item)
-		case 0xd9:
-			let tag = UInt8(try readUInt(2) as UInt16)
-			guard let item = try decodeItem() else { throw CBORError.unfinishedSequence }
-			return CBOR.tagged(tag, item)
-		case 0xda:
-			let tag = UInt8(try readUInt(4) as UInt32)
-			guard let item = try decodeItem() else { throw CBORError.unfinishedSequence }
-			return CBOR.tagged(tag, item)
-		case 0xdb:
-			let tag = UInt8(try readUInt(8) as UInt64)
-			guard let item = try decodeItem() else { throw CBORError.unfinishedSequence }
-			return CBOR.tagged(tag, item)
+			return CBOR.tagged(CBOR.Tag(rawValue: tag), item)
 
-		case let b where 0xe0 <= b && b <= 0xf3: return CBOR.simple(b - 0xe0)
+		case 0xe0...0xf3: return CBOR.simple(b - 0xe0)
 		case 0xf4: return CBOR.boolean(false)
 		case 0xf5: return CBOR.boolean(true)
 		case 0xf6: return CBOR.null
@@ -170,16 +155,34 @@ public class CBORDecoder {
 		case 0xf8: return CBOR.simple(try istream.popByte())
 
 		case 0xf9:
-            let ptr = UnsafeRawPointer(Array(try istream.popBytes(2).reversed())).bindMemory(to: UInt16.self, capacity: 1)
-            return CBOR.half(loadFromF16(ptr))
+			var data = try readBinaryNumber(UInt16.self)
+			let half = withUnsafePointer(to: &data) { loadFromF16($0) }
+			return CBOR.half(half)
 		case 0xfa:
-            return CBOR.float(UnsafeRawPointer(Array(try istream.popBytes(4).reversed())).load(as: Float32.self))
+			return CBOR.float(try readBinaryNumber(Float32.self))
 		case 0xfb:
-            return CBOR.double(UnsafeRawPointer(Array(try istream.popBytes(8).reversed())).load(as: Float64.self))
+			return CBOR.double(try readBinaryNumber(Float64.self))
 
 		case 0xff: return CBOR.break
 		default: return nil
 		}
 	}
 
+}
+
+private enum VarUIntSize: UInt8 {
+	case uint8 = 0
+	case uint16 = 1
+	case uint32 = 2
+	case uint64 = 3
+
+	init(rawValue: UInt8) {
+		switch rawValue & 0b11 {
+		case 0: self = .uint8
+		case 1: self = .uint16
+		case 2: self = .uint32
+		case 3: self = .uint64
+		default: fatalError() // mask only allows values from 0-3
+		}
+	}
 }

--- a/SwiftCBOR/CBOREncodable.swift
+++ b/SwiftCBOR/CBOREncodable.swift
@@ -8,8 +8,8 @@ extension CBOR: CBOREncodable {
     /// Encodes a wrapped CBOR value. CBOR.half (Float16) is not supported and encodes as `undefined`.
     public func encode() -> [UInt8] {
         switch self {
-        case let .unsignedInt(ui): return ui.encode()
-        case let .negativeInt(ni): return (-Int(ni) - 1).encode()
+        case let .unsignedInt(ui): return CBOR.encodeVarUInt(ui)
+        case let .negativeInt(ni): return CBOR.encodeNegativeInt(~Int64(bitPattern: ni))
         case let .byteString(bs): return CBOR.encodeByteString(bs)
         case let .utf8String(str): return str.encode()
         case let .array(a): return CBOR.encodeArray(a)
@@ -30,32 +30,16 @@ extension CBOR: CBOREncodable {
 extension Int: CBOREncodable {
     public func encode() -> [UInt8] {
         if (self < 0) {
-            return CBOR.encodeNegativeInt(self)
+            return CBOR.encodeNegativeInt(Int64(self))
         } else {
-            let uint64 = UInt64(self)
-            switch uint64 {
-            case let x where x <= UInt8.max: return CBOR.encodeUInt8(UInt8(x))
-            case let x where x <= UInt16.max: return CBOR.encodeUInt16(UInt16(x))
-            case let x where x <= UInt32.max: return CBOR.encodeUInt32(UInt32(x))
-            default: return CBOR.encodeUInt64(uint64)
-            }
+            return CBOR.encodeVarUInt(UInt64(self))
         }
     }
 }
 
 extension UInt: CBOREncodable {
     public func encode() -> [UInt8] {
-        switch self {
-        case let x where x <= UInt8.max: return CBOR.encodeUInt8(UInt8(x))
-        case let x where x <= UInt16.max: return CBOR.encodeUInt16(UInt16(x))
-        case let x where x <= UInt32.max: return CBOR.encodeUInt32(UInt32(x))
-        default: return CBOR.encodeUInt64(UInt64(self))
-//        if MemoryLayout<UInt>.size == 4 {
-//            return CBOR.encodeUInt32(UInt32(self))
-//        } else {
-//            return CBOR.encodeUInt64(UInt64(self))
-//        }
-        }
+		return CBOR.encodeVarUInt(UInt64(self))
     }
 }
 

--- a/SwiftCBORTests/CBORDecoderTests.swift
+++ b/SwiftCBORTests/CBORDecoderTests.swift
@@ -5,18 +5,18 @@ class CBORDecoderTests: XCTestCase {
 
 	func testDecodeNumbers() {
 		for i in (0..<24) {
-            XCTAssertEqual(try! CBORDecoder(input: [UInt8(i)]).decodeItem(), CBOR.unsignedInt(UInt(i)))
+			XCTAssertEqual(try! CBORDecoder(input: [UInt8(i)]).decodeItem(), CBOR.unsignedInt(UInt64(i)))
 		}
-        XCTAssertEqual(try! CBORDecoder(input: [0x18, 0xff]).decodeItem(), 255)
-        XCTAssertEqual(try! CBORDecoder(input: [0x19, 0x03, 0xe8]).decodeItem(), 1000) // Network byte order!
-        XCTAssertEqual(try! CBORDecoder(input: [0x19, 0xff, 0xff]).decodeItem(), 65535)
+		XCTAssertEqual(try! CBORDecoder(input: [0x18, 0xff]).decodeItem(), 255)
+		XCTAssertEqual(try! CBORDecoder(input: [0x19, 0x03, 0xe8]).decodeItem(), 1000) // Network byte order!
+		XCTAssertEqual(try! CBORDecoder(input: [0x19, 0xff, 0xff]).decodeItem(), 65535)
 		do { _ = try CBORDecoder(input: [0x19, 0xff]).decodeItem(); XCTAssertTrue(false) } catch { XCTAssertTrue(true) }
-        XCTAssertEqual(try! CBORDecoder(input: [0x1a, 0x00, 0x0f, 0x42, 0x40]).decodeItem(), 1000000)
-        XCTAssertEqual(try! CBORDecoder(input: [0x1a, 0xff, 0xff, 0xff, 0xff]).decodeItem(), 4294967295)
+		XCTAssertEqual(try! CBORDecoder(input: [0x1a, 0x00, 0x0f, 0x42, 0x40]).decodeItem(), 1000000)
+		XCTAssertEqual(try! CBORDecoder(input: [0x1a, 0xff, 0xff, 0xff, 0xff]).decodeItem(), 4294967295)
 		do { _ = try CBORDecoder(input: [0x1a]).decodeItem(); XCTAssertTrue(false) } catch { XCTAssertTrue(true) }
-        XCTAssertEqual(try! CBORDecoder(input: [0x1b, 0x00, 0x00, 0x00, 0xe8, 0xd4, 0xa5, 0x10, 0x00]).decodeItem(), 1000000000000)
-        XCTAssertEqual(try! CBORDecoder(input: [0x1b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]).decodeItem(), CBOR.unsignedInt(18446744073709551615))
-        do { _ = try CBORDecoder(input: [0x1b, 0x00, 0x00]).decodeItem(); XCTAssertTrue(false) } catch { XCTAssertTrue(true) }
+		XCTAssertEqual(try! CBORDecoder(input: [0x1b, 0x00, 0x00, 0x00, 0xe8, 0xd4, 0xa5, 0x10, 0x00]).decodeItem(), 1000000000000)
+		XCTAssertEqual(try! CBORDecoder(input: [0x1b, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]).decodeItem(), CBOR.unsignedInt(18446744073709551615))
+		do { _ = try CBORDecoder(input: [0x1b, 0x00, 0x00]).decodeItem(); XCTAssertTrue(false) } catch { XCTAssertTrue(true) }
 
 		XCTAssertEqual(try! CBORDecoder(input: [0x20]).decodeItem(), -1)
 		XCTAssertEqual(try! CBORDecoder(input: [0x21]).decodeItem(), CBOR.negativeInt(1))
@@ -64,13 +64,13 @@ class CBORDecoderTests: XCTestCase {
 		XCTAssertEqual(try! CBORDecoder(input: [0xb8, 1, 0x63, 0x6b, 0x65, 0x79, 0x81, 0x37]).decodeItem(), ["key" : [-24]])
 		XCTAssertEqual(try! CBORDecoder(input: [0xbf, 0x63, 0x6b, 0x65, 0x79, 0xa1, 0x63, 0x6b, 0x65, 0x79, 0x37, 0xff]).decodeItem(), ["key" : ["key" : -24]])
 	}
-    
+
 	func testDecodeTagged() {
-		XCTAssertEqual(try! CBORDecoder(input: [0xc0, 0x79, 0x00, 3, 0x41, 0x42, 0x43]).decodeItem(), CBOR.tagged(0, "ABC"))
-		XCTAssertEqual(try! CBORDecoder(input: [0xd8, 255, 0x79, 0x00, 3, 0x41, 0x42, 0x43]).decodeItem(), CBOR.tagged(255, "ABC"))
-		XCTAssertEqual(try! CBORDecoder(input: [0xdb, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 3, 0xbf, 0x63, 0x6b, 0x65, 0x79, 0xa1, 0x63, 0x6b, 0x65, 0x79, 0x37, 0xff]).decodeItem(), CBOR.tagged(3, ["key" : ["key" : -24]]))
+		XCTAssertEqual(try! CBORDecoder(input: [0xc0, 0x79, 0x00, 3, 0x41, 0x42, 0x43]).decodeItem(), CBOR.tagged(.standardDateTimeString, "ABC"))
+		XCTAssertEqual(try! CBORDecoder(input: [0xd8, 255, 0x79, 0x00, 3, 0x41, 0x42, 0x43]).decodeItem(), CBOR.tagged(.init(rawValue: 255), "ABC"))
+		XCTAssertEqual(try! CBORDecoder(input: [0xdb, 255, 255, 255, 255, 255, 255, 255, 255, 0x79, 0x00, 3, 0x41, 0x42, 0x43]).decodeItem(), CBOR.tagged(.init(rawValue: UInt64.max), "ABC"))
+		XCTAssertEqual(try! CBORDecoder(input: [0xdb, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 3, 0xbf, 0x63, 0x6b, 0x65, 0x79, 0xa1, 0x63, 0x6b, 0x65, 0x79, 0x37, 0xff]).decodeItem(), CBOR.tagged(.negativeBignum, ["key" : ["key" : -24]]))
 	}
-    
 
 	func testDecodeSimple() {
 		XCTAssertEqual(try! CBORDecoder(input: [0xe0]).decodeItem(), CBOR.simple(0))
@@ -81,7 +81,6 @@ class CBORDecoderTests: XCTestCase {
 		XCTAssertEqual(try! CBORDecoder(input: [0xf6]).decodeItem(), CBOR.null)
 		XCTAssertEqual(try! CBORDecoder(input: [0xf7]).decodeItem(), CBOR.undefined)
 	}
-
 
 	func testDecodeFloats() {
 		XCTAssertEqual(try! CBORDecoder(input: [0xf9, 0xc4, 0x00]).decodeItem(), CBOR.half(-4.0))

--- a/SwiftCBORTests/CBOREncoderTests.swift
+++ b/SwiftCBORTests/CBOREncoderTests.swift
@@ -62,9 +62,9 @@ class CBOREncoderTests: XCTestCase {
         XCTAssertEqual(CBOR.encode(Array<Int>()), [0x80])
         XCTAssertEqual(CBOR.encode([1, 2, 3]), [0x83, 0x01, 0x02, 0x03])
 
-        let arr: [[Int]] = [[1], [2, 3], [4, 5]]
+        let arr: [[UInt64]] = [[1], [2, 3], [4, 5]]
        
-        let wrapped = arr.map{ inner in return CBOR.array(inner.map{ return CBOR.unsignedInt(UInt($0)) })}
+        let wrapped = arr.map{ inner in return CBOR.array(inner.map{ return CBOR.unsignedInt($0) })}
         print(wrapped)
         XCTAssertEqual(CBOR.encode(wrapped), [0x83, 0x81, 0x01, 0x82, 0x02, 0x03, 0x82, 0x04, 0x05])
         
@@ -89,7 +89,8 @@ class CBOREncoderTests: XCTestCase {
     func testEncodeTagged() {
         let bignum: [UInt8] = [0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00] // 2**64
         let bignumCBOR = CBOR.byteString(bignum)
-        XCTAssertEqual(CBOR.encodeTagged(tag: 2, value: bignumCBOR), [0xc2, 0x49] + bignum)
+        XCTAssertEqual(CBOR.encodeTagged(tag: .positiveBignum, value: bignumCBOR), [0xc2, 0x49] + bignum)
+		XCTAssertEqual(CBOR.encodeTagged(tag: .init(rawValue: UInt64.max), value: bignumCBOR), [0xdb, 255, 255, 255, 255, 255, 255, 255, 255, 0x49] + bignum)
     }
 
     func testEncodeSimple() {


### PR DESCRIPTION
Hi Greg,

I started out to support larger tags but somehow got lured into a refactoring spree.

- Support for tags larger than 255 (and add an extensible struct with known values from the spec).
- Default to UInt64 instead of platform-specific width.
- Extracted `readBinaryNumber` to reduce the large decoder `switch`.
- Extracted `encodeVarUInt`.
- Added error that is thrown if sequence is too large for platform (i.e. larger than `Int`).

Let me know if you think I should break this down more.

Cheers,
Marcel