### PR TITLE
Handle decoding empty, indefinite-length maps

### DIFF
--- a/Sources/SwiftCBOR/CBORDecoder.swift
+++ b/Sources/SwiftCBOR/CBORDecoder.swift
@@ -83,6 +83,9 @@ public class CBORDecoder {
     private func readPairsUntilBreak() throws -> [CBOR : CBOR] {
         var result: [CBOR: CBOR] = [:]
         var key = try decodeItem()
+        if key == CBOR.break {
+            return result
+        }
         var val = try decodeItem()
         while key != CBOR.break {
             guard let okey = key else { throw CBORError.unfinishedSequence }


### PR DESCRIPTION
CBORDecoder would fail parsing the map `0xbf, 0xff`