### PR TITLE
Ensure compatibility with Xcode 11

### DIFF
--- a/Sources/SwiftCBOR/CBOR.swift
+++ b/Sources/SwiftCBOR/CBOR.swift
@@ -128,6 +128,7 @@ public indirect enum CBOR : Equatable, Hashable,
         case (.float,       _): return false
         case (.double,      _): return false
         case (.break,       _): return false
+        default:                return false
         }
     }
 


### PR DESCRIPTION
Since the switch statement is not exhaustive, Xcode 11 stops the building process with this error message `The compiler is unable to check that this switch is exhaustive in reasonable time`. By making it exhaustive, the frameworks builds with Xcode 11 and Swift 5 like a charm even using the Package Manager within Xcode 11.