### PR TITLE
Lower Bool encoding precedence when working with `Any`

### DIFF
--- a/Sources/SwiftCBOR/CBOREncoder.swift
+++ b/Sources/SwiftCBOR/CBOREncoder.swift
@@ -262,8 +262,6 @@ extension CBOR {
 
     private static func encodeAny(_ any: Any) throws -> [UInt8] {
         switch any {
-        case is Bool:
-            return (any as! Bool).encode()
         case is Int:
             return (any as! Int).encode()
         case is UInt:
@@ -282,6 +280,8 @@ extension CBOR {
             return (any as! Float).encode()
         case is Double:
             return (any as! Double).encode()
+        case is Bool:
+            return (any as! Bool).encode()
         case is [UInt8]:
             return CBOR.encodeByteString(any as! [UInt8])
         #if canImport(Foundation)


### PR DESCRIPTION
When encoding an Any the check for Bool was highest precedence which meant that if you were working with Objective-C and you had an integer value of 0 or 1 that you wanted to encode as a numeric value then it would be encoded as a Bool. This lowers the precedence of checking for a Bool to be lower than the numeric checks.