### PR TITLE
Specify dylib compatibility version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,4 +27,4 @@ jobs:
     - name: Test macOS
       run: xcodebuild test -project SwiftCBOR.xcodeproj -scheme SwiftCBOR-Package -destination 'platform=OS X,arch=x86_64'
     - name: Test iOS
-      run: xcodebuild test -project SwiftCBOR.xcodeproj -scheme SwiftCBOR-Package -destination 'platform=iOS Simulator,name=iPhone X,OS=12.2'
+      run: xcodebuild test -project SwiftCBOR.xcodeproj -scheme SwiftCBOR-Package -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.1'

--- a/SwiftCBOR.xcodeproj/project.pbxproj
+++ b/SwiftCBOR.xcodeproj/project.pbxproj
@@ -170,6 +170,8 @@
             COMBINE_HIDPI_IMAGES = "YES";
             COPY_PHASE_STRIP = "NO";
             DEBUG_INFORMATION_FORMAT = "dwarf";
+            DYLIB_COMPATIBILITY_VERSION = 1;
+            DYLIB_CURRENT_VERSION = 1;
             DYLIB_INSTALL_NAME_BASE = "@rpath";
             ENABLE_NS_ASSERTIONS = "YES";
             GCC_OPTIMIZATION_LEVEL = "0";
@@ -256,6 +258,8 @@
             COMBINE_HIDPI_IMAGES = "YES";
             COPY_PHASE_STRIP = "YES";
             DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+            DYLIB_COMPATIBILITY_VERSION = 1;
+            DYLIB_CURRENT_VERSION = 1;
             DYLIB_INSTALL_NAME_BASE = "@rpath";
             GCC_OPTIMIZATION_LEVEL = "s";
             GCC_PREPROCESSOR_DEFINITIONS = (


### PR DESCRIPTION
Sets the dylib compatibility versions used in build to match those generated by a Pods build. Currently a binary framework that depends on this framework cannot use an output built by a Carthage build if the downstream framework was built by Pods, as the dylib version specifications aren't compatible.