### PR TITLE
Allow for use in app extensions

### DIFF
--- a/SwiftCBOR.xcodeproj/project.pbxproj
+++ b/SwiftCBOR.xcodeproj/project.pbxproj
@@ -350,6 +350,7 @@
          isa = "XCBuildConfiguration";
          baseConfigurationReference = "OBJ_8";
          buildSettings = {
+            APPLICATION_EXTENSION_API_ONLY = YES;
             ENABLE_TESTABILITY = "YES";
             FRAMEWORK_SEARCH_PATHS = (
                "$(inherited)",
@@ -409,6 +410,7 @@
          isa = "XCBuildConfiguration";
          baseConfigurationReference = "OBJ_8";
          buildSettings = {
+            APPLICATION_EXTENSION_API_ONLY = YES;
             ENABLE_TESTABILITY = "YES";
             FRAMEWORK_SEARCH_PATHS = (
                "$(inherited)",


### PR DESCRIPTION
When using the Carthage build we get a warning that the Framework wasn't built for use in app extensions. PR just sets a flag in project to mark it as safe for use in extensions to get rid of this warning.