### PR TITLE
Remove Xcode path from LD_RUNPATH_SEARCH_PATHS

### DIFF
--- a/SwiftCBOR.xcodeproj/project.pbxproj
+++ b/SwiftCBOR.xcodeproj/project.pbxproj
@@ -363,7 +363,8 @@
             IPHONEOS_DEPLOYMENT_TARGET = "8.0";
             LD_RUNPATH_SEARCH_PATHS = (
                "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+               "@executable_path/../Frameworks",
+               "@loader_path/Frameworks"
             );
             MACOSX_DEPLOYMENT_TARGET = "10.10";
             OTHER_CFLAGS = (
@@ -423,7 +424,8 @@
             IPHONEOS_DEPLOYMENT_TARGET = "8.0";
             LD_RUNPATH_SEARCH_PATHS = (
                "$(inherited)",
-               "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx"
+               "@executable_path/../Frameworks",
+               "@loader_path/Frameworks"
             );
             MACOSX_DEPLOYMENT_TARGET = "10.10";
             OTHER_CFLAGS = (


### PR DESCRIPTION
We ran into an issue on MacOS 10.3 where SwiftCBOR was trying to load incompatible Swift libraries from an old version of Xcode. It seems this is because the RPATH contains hardcoded links to Xcode added by Swift Package Manager for this module. See https://developer.apple.com/forums/thread/115551

This PR removes the Xcode specific RPATH entry for SwiftCBOR binaries.