### PR TITLE
add option to sort maps by key

### DIFF
--- a/Sources/CBOROptions.swift
+++ b/Sources/CBOROptions.swift
@@ -4,17 +4,20 @@ public struct CBOROptions {
     let forbidNonStringMapKeys: Bool
     /// The maximum number of nested items, inclusive, to decode. A maximum set to 0 dissallows anything other than top-level primitives.
     let maximumDepth: Int
+    let shouldSortMapKeys: Bool
 
     public init(
         useStringKeys: Bool = false,
         dateStrategy: DateStrategy = .taggedAsEpochTimestamp,
         forbidNonStringMapKeys: Bool = false,
-        maximumDepth: Int = .max
+        maximumDepth: Int = .max,
+        shouldShortMapKeys: Bool = true
     ) {
         self.useStringKeys = useStringKeys
         self.dateStrategy = dateStrategy
         self.forbidNonStringMapKeys = forbidNonStringMapKeys
         self.maximumDepth = maximumDepth
+        self.shouldSortMapKeys = shouldShortMapKeys
     }
 
     func toCodableEncoderOptions() -> CodableCBOREncoder._Options {

--- a/Tests/CBOREncoderTests.swift
+++ b/Tests/CBOREncoderTests.swift
@@ -102,7 +102,7 @@ class CBOREncoderTests: XCTestCase {
             "a": 1,
             "b": [2, 3]
         ]
-        let encodedMapToAny = try! CBOR.encodeMap(mapToAny)
+        let encodedMapToAny = try! CBOR.encodeMap(mapToAny, options: .init(shouldShortMapKeys: true))
         XCTAssertEqual(encodedMapToAny, [0xa2, 0x61, 0x61, 0x01, 0x61, 0x62, 0x82, 0x02, 0x03])
 
         let mapToAnyWithIntKeys: [Int: Any] = [
@@ -112,6 +112,19 @@ class CBOREncoderTests: XCTestCase {
         XCTAssertThrowsError(try CBOR.encodeMap(mapToAnyWithIntKeys, options: CBOROptions(forbidNonStringMapKeys: true))) { err in
             XCTAssertEqual(err as! CBOREncoderError, CBOREncoderError.nonStringKeyInMap)
         }
+    }
+    
+    func testEncodeSortedMaps() {
+        XCTAssertEqual(CBOR.encode(Dictionary<Int, Int>()), [0xa0])
+
+        let encoded = CBOR.encode([3: 4, 1: 2])
+        XCTAssert(encoded == [0xa2, 0x01, 0x02, 0x03, 0x04])
+
+        let arr1: CBOR = [1]
+        let arr2: CBOR = [2,3]
+        let nestedEnc: [UInt8] = CBOR.encode(["b": arr2, "a": arr1])
+        let encodedAFirst: [UInt8] = [0xa2, 0x61, 0x61, 0x81, 0x01, 0x61, 0x62, 0x82, 0x02, 0x03]
+        XCTAssert(nestedEnc == encodedAFirst)
     }
 
     func testEncodeTagged() {


### PR DESCRIPTION
Hi there.

To contribute I added this option that I found to be useful so before encoding the encoder first sorts the keys. I found a similar logic was already being used for Map<CBOREncodable, Any> so I added the option so maps are sorted by key.

So it doesn't cause any breaking change this flag is set to true by default.