### PR TITLE
fix: typo in `CBOROptions` parameter: `shouldShortMapKeys` → `shouldSortMapKeys`

### DIFF
--- a/Sources/CBOROptions.swift
+++ b/Sources/CBOROptions.swift
@@ -11,13 +11,13 @@ public struct CBOROptions {
         dateStrategy: DateStrategy = .taggedAsEpochTimestamp,
         forbidNonStringMapKeys: Bool = false,
         maximumDepth: Int = .max,
-        shouldShortMapKeys: Bool = true
+        shouldSortMapKeys: Bool = true
     ) {
         self.useStringKeys = useStringKeys
         self.dateStrategy = dateStrategy
         self.forbidNonStringMapKeys = forbidNonStringMapKeys
         self.maximumDepth = maximumDepth
-        self.shouldSortMapKeys = shouldShortMapKeys
+        self.shouldSortMapKeys = shouldSortMapKeys
     }
 
     func toCodableEncoderOptions() -> CodableCBOREncoder._Options {

--- a/Tests/CBOREncoderTests.swift
+++ b/Tests/CBOREncoderTests.swift
@@ -102,7 +102,7 @@ class CBOREncoderTests: XCTestCase {
             "a": 1,
             "b": [2, 3]
         ]
-        let encodedMapToAny = try! CBOR.encodeMap(mapToAny, options: .init(shouldShortMapKeys: true))
+        let encodedMapToAny = try! CBOR.encodeMap(mapToAny, options: .init(shouldSortMapKeys: true))
         XCTAssertEqual(encodedMapToAny, [0xa2, 0x61, 0x61, 0x01, 0x61, 0x62, 0x82, 0x02, 0x03])
 
         let mapToAnyWithIntKeys: [Int: Any] = [


### PR DESCRIPTION
The parameter name in `CBOROptions.init()` was incorrectly spelled as `shouldShortMapKeys` when it should be `shouldSortMapKeys` to match the property name and convey the correct meaning (sorting keys, not shortening them).