### PR TITLE
compile on freebsd

### DIFF
--- a/Sources/CBOR.swift
+++ b/Sources/CBOR.swift
@@ -174,6 +174,6 @@ extension CBOR.Tag {
     public static let selfDescribeCBOR = CBOR.Tag(rawValue: 55799)
 }
 
-#if os(Linux) || os(Windows) || os(Android)
+#if os(Linux) || os(Windows) || os(Android) || os(FreeBSD)
 let NSEC_PER_SEC: UInt64 = 1_000_000_000
 #endif


### PR DESCRIPTION
Compile support on FreeBSD.

Tested on FreeBSD 15.1

Example build log below
```
$ freebsd-version -k
15.1-RELEASE-p1

$ swift build
Building for debugging...
[1/1] Write swift-version-5A2F66DD58373410.txt
Build complete! (0.15s)

$ swift -version
Swift version 6.3-dev (LLVM 7c51e5dc68daf76, Swift cc8e6fd8770ad14)
Target: x86_64-unknown-freebsd14.3
Build config: +assertions
```