### PR TITLE
Add support for multiple key containers

### DIFF
--- a/Sources/Encoder/CodableCBOREncoder.swift
+++ b/Sources/Encoder/CodableCBOREncoder.swift
@@ -93,12 +93,17 @@ extension _CBOREncoder: Encoder {
     }
 
     func container<Key: CodingKey>(keyedBy type: Key.Type) -> KeyedEncodingContainer<Key> {
-        assertCanCreateContainer()
-
-        let container = KeyedContainer<Key>(codingPath: self.codingPath, userInfo: self.userInfo, options: self.options)
-        self.container = container
-
-        return KeyedEncodingContainer(container)
+        if let container = self.container as? AnyKeyedContainer {
+            let container = KeyedContainer<Key>(storage: container.storage, codingPath: self.codingPath, userInfo: self.userInfo, options: self.options)
+            return KeyedEncodingContainer(container)
+        } else {
+            assertCanCreateContainer()
+            
+            let container = KeyedContainer<Key>(codingPath: self.codingPath, userInfo: self.userInfo, options: self.options)
+            self.container = container
+            
+            return KeyedEncodingContainer(container)
+        }
     }
 
     func unkeyedContainer() -> UnkeyedEncodingContainer {

--- a/Sources/Encoder/KeyedEncodingContainer.swift
+++ b/Sources/Encoder/KeyedEncodingContainer.swift
@@ -1,15 +1,24 @@
 import Foundation
 
+protocol AnyKeyedContainer {
+    var storage: KeyedContainerStorage { get }
+}
+
+final class KeyedContainerStorage {
+    var entries: [AnyCodingKey: CBOREncodingContainer] = [:]
+}
+
 extension _CBOREncoder {
-    final class KeyedContainer<Key: CodingKey> {
-        var storage: [AnyCodingKey: CBOREncodingContainer] = [:]
+    final class KeyedContainer<Key: CodingKey>: AnyKeyedContainer {
+        var storage: KeyedContainerStorage
 
         var codingPath: [CodingKey]
         var userInfo: [CodingUserInfoKey: Any]
 
         let options: CodableCBOREncoder._Options
 
-        init(codingPath: [CodingKey], userInfo: [CodingUserInfoKey : Any], options: CodableCBOREncoder._Options) {
+        init(storage: KeyedContainerStorage = KeyedContainerStorage(), codingPath: [CodingKey], userInfo: [CodingUserInfoKey : Any], options: CodableCBOREncoder._Options) {
+            self.storage = storage
             self.codingPath = codingPath
             self.userInfo = userInfo
             self.options = options
@@ -38,7 +47,7 @@ extension _CBOREncoder.KeyedContainer: KeyedEncodingContainerProtocol {
             userInfo: self.userInfo,
             options: self.options
         )
-        self.storage[anyCodingKeyForKey(key)] = container
+        self.storage.entries[anyCodingKeyForKey(key)] = container
         return container
     }
 
@@ -48,7 +57,7 @@ extension _CBOREncoder.KeyedContainer: KeyedEncodingContainerProtocol {
             userInfo: self.userInfo,
             options: self.options
         )
-        self.storage[anyCodingKeyForKey(key)] = container
+        self.storage.entries[anyCodingKeyForKey(key)] = container
         return container
     }
 
@@ -58,7 +67,7 @@ extension _CBOREncoder.KeyedContainer: KeyedEncodingContainerProtocol {
             userInfo: self.userInfo,
             options: self.options
         )
-        self.storage[anyCodingKeyForKey(key)] = container
+        self.storage.entries[anyCodingKeyForKey(key)] = container
         return KeyedEncodingContainer(container)
     }
 
@@ -79,9 +88,9 @@ extension _CBOREncoder.KeyedContainer: CBOREncodingContainer {
     var data: Data {
         // TODO: Check that this works for all sizes of map
         var data: [UInt8] = []
-        data = storage.count.encode()
+        data = storage.entries.count.encode()
         data[0] = data[0] | 0b101_00000
-        for (key, container) in self.storage {
+        for (key, container) in self.storage.entries {
             let keyContainer = _CBOREncoder.SingleValueContainer(codingPath: self.codingPath, userInfo: self.userInfo, options: self.options)
             try! keyContainer.encode(key)
             data.append(contentsOf: keyContainer.data)

--- a/Tests/CBOREncoderTests.swift
+++ b/Tests/CBOREncoderTests.swift
@@ -348,4 +348,69 @@ class CBOREncoderTests: XCTestCase {
         let decoded = try! CodableCBORDecoder().decode(MyCodableThing.self, from: Data(encoded))
         XCTAssertEqual(decoded, myCodableThing)
     }
+    
+    func testEncodeVariant() {
+        enum Variant: Codable, Equatable {
+            case small(Small)
+            case large(Large)
+            
+            struct Small: Codable, Equatable {
+                var value: Int
+            }
+            
+            struct Large: Codable, Equatable {
+                var label: String
+                var value: Int
+            }
+            
+            private enum Style: String, Codable {
+                case small
+                case large
+            }
+            
+            private enum CodingKeys: String, CodingKey {
+                case style
+            }
+            
+            func encode(to encoder: any Encoder) throws {
+                var container = encoder.container(keyedBy: CodingKeys.self)
+                switch self {
+                case .small(let small):
+                    try container.encode(Style.small, forKey: .style)
+                    try small.encode(to: encoder)
+                case .large(let large):
+                    try container.encode(Style.large, forKey: .style)
+                    try large.encode(to: encoder)
+                }
+            }
+            
+            init(from decoder: any Decoder) throws {
+                let container = try decoder.container(keyedBy: CodingKeys.self)
+                let style = try container.decode(Style.self, forKey: .style)
+                switch style {
+                case .small:
+                    self = try .small(Small(from: decoder))
+                case .large:
+                    self = try .large(Large(from: decoder))
+                }
+            }
+        }
+        
+        let smallValue = Int.random(in: 50...50000)
+        let largeValue = Int.random(in: 50...50000)
+        let largeLabel = UUID().uuidString
+        
+        let originalSmall = Variant.small(.init(value: smallValue))
+        let originalLarge = Variant.large(.init(label: largeLabel, value: largeValue))
+        
+        let encodedSmall = try! CBOR.encodeAny(originalSmall)
+        let encodedLarge = try! CBOR.encodeAny(originalLarge)
+        
+        let decodedSmall = try! CodableCBORDecoder().decode(Variant.self, from: Data(encodedSmall))
+        let decodedLarge = try! CodableCBORDecoder().decode(Variant.self, from: Data(encodedLarge))
+        
+        XCTAssertEqual(decodedSmall, originalSmall)
+        XCTAssertEqual(decodedLarge, originalLarge)
+        XCTAssertEqual(decodedLarge, originalLarge)
+    }
 }


### PR DESCRIPTION
This is a pattern used when multiple objects are being used to encode and decode values, as in the testEncodeVariant test this commit adds. This sort of behaviour already works for JSONEncoder so I thought it would be good to bring support for it here.

I've found it useful in somewhat niche cases with json when dealing with multiple potential data types coming from a single payload, and I've also found an instance where I'd like to use it in cbor as well, so I'm trying to get it added to this library.